### PR TITLE
修复项目文件中的 IsMac 属性设置，确保默认值为 false

### DIFF
--- a/DisplayItemValue/DisplayItemValue.csproj
+++ b/DisplayItemValue/DisplayItemValue.csproj
@@ -2,6 +2,7 @@
     <PropertyGroup>
         <TargetFramework>netstandard2.1</TargetFramework>
         <Nullable>enable</Nullable>
+        <IsMac>false</IsMac>
         <IsMac Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::OSX)))'">true</IsMac>
 
         <!-- For Windows users, please fill the folder path which contains Duckov.exe below -->


### PR DESCRIPTION
<img width="453" height="166" alt="image" src="https://github.com/user-attachments/assets/3412e6cc-b730-4216-876c-8d5d1e76b714" />
今天研究mod的时候发现了这个报错，所以修复一下