### PR TITLE
csproj: do not copy unnecessary DLL files

### DIFF
--- a/DisplayItemValue/DisplayItemValue.csproj
+++ b/DisplayItemValue/DisplayItemValue.csproj
@@ -17,8 +17,14 @@
 
     </PropertyGroup>
     <ItemGroup>
-        <Reference Include="$(DuckovPath)$(SubPath)TeamSoda.*"/>
-        <Reference Include="$(DuckovPath)$(SubPath)ItemStatsSystem.dll"/>
-        <Reference Include="$(DuckovPath)$(SubPath)Unity*"/>
+        <Reference Include="$(DuckovPath)$(SubPath)TeamSoda.*">
+	      <Private>False</Private>
+	    </Reference>
+        <Reference Include="$(DuckovPath)$(SubPath)ItemStatsSystem.dll">
+	      <Private>False</Private>
+	    </Reference>
+        <Reference Include="$(DuckovPath)$(SubPath)Unity*">
+	      <Private>False</Private>
+	    </Reference>
     </ItemGroup>
 </Project>


### PR DESCRIPTION
不会影响编译，而且输出路径不再拷贝非必要的 dll 文件，更改之后就只有三个自己生成的文件，清爽了很多，也不需要再费力在一堆 dll 里面找自己需要的了
<img width="685" height="142" alt="Snipaste_2025-11-08_16-18-05" src="https://github.com/user-attachments/assets/b73c6d0d-3a89-40fa-9b2d-7857fe048551" />
